### PR TITLE
add iosevka font for xmobar

### DIFF
--- a/homes/del/xmobar.nix
+++ b/homes/del/xmobar.nix
@@ -1,4 +1,7 @@
-_: {
+{ pkgs, ... }: {
+  home.packages = [
+    pkgs.iosevka
+  ];
   programs.xmobar = {
     enable = true;
     extraConfig = builtins.readFile ./xmobarrc;

--- a/homes/del/xmobarrc
+++ b/homes/del/xmobarrc
@@ -1,6 +1,6 @@
 Config
   { overrideRedirect = False
-  , font = "xft:iosevka-13"
+  , font = "Iosevka 13"
   , bgColor = "#000000"
   , fgColor = "#f8f8f2"
   , position = TopW L 100


### PR DESCRIPTION
You are using Iosevka font for xmobar but it wasn't in the home-manager closure. This fixes that. =D

Also it seems like xft is dropped so I'm surprised that it still worked.
https://codeberg.org/xmobar/xmobar/src/branch/master/changelog.md#version-0-45-october-2022


<img width="1183" height="261" alt="image" src="https://github.com/user-attachments/assets/202715bf-4c97-4b83-af55-55e134f0dfab" />


---
Tested with the following patch and command.
```bash
nix build .#nixosConfigurations.hepao.config.system.build.vm
result/bin/run-hepao-vm
```


```diff
diff --git a/flake.nix b/flake.nix
index 98fd2e8..a7bcdbd 100644
--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,18 @@
           [
             hardware.framework-12th-gen-intel
             hosts.hepao
+
+            {
+              nixpkgs.config.allowUnfree = true;
+            }
+            (inputs.home-manager + "/nixos")
+            { home-manager.users.del = {
+                imports = [ ./homes/del ];
+                home.stateVersion = stateVersion;
+                nixpkgs.config.allowUnfree = true;
+              };
+            }
+
           ]
           ++ modules.workstation;
       };
diff --git a/hosts/_/workstation.nix b/hosts/_/workstation.nix
index da6d63d..44dd695 100644
--- a/hosts/_/workstation.nix
+++ b/hosts/_/workstation.nix
@@ -11,7 +11,7 @@
   services = {
     avahi.enable = true;
     btrfs.autoScrub = {
-      enable = true;
+      # enable = true;
       interval = "weekly";
     };
 
```

