### PR TITLE
Remove gcc from neovim module

### DIFF
--- a/homes/del/neovim.nix
+++ b/homes/del/neovim.nix
@@ -12,7 +12,6 @@
 in {
   home.packages = with pkgs;
     [
-      gcc # needed by nvim-treesitter
       ghc # needed by haskell-language-server
       lsof # used by the opencode plugin to retrieve the server
       xclip # used by neovim to manage the clipboard


### PR DESCRIPTION
gcc is only used to compile the grammar when neovim is managed imperatively.
Here, the grammar is already managed and compiled by nix configuration.
We can safely remove gcc.

This is documented [here](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/neovim.section.md#treesitter-setup-using-nvim-treesitter-neovim-plugin-nvim-treesitter) 